### PR TITLE
Prevent triggers from firing early

### DIFF
--- a/watchman.js
+++ b/watchman.js
@@ -162,7 +162,7 @@ var watch = function(file, expression, callback) {
                 expression: expression,
                 callback: callback };
     watchList.push(obj);
-    var watcher = chokidar.watch(obj.file, {persistent: true});
+    var watcher = chokidar.watch(obj.file, {persistent: true, ignoreInitial: true});
     if(obj.callback.add != undefined)
         watcher.on('add', wrapCallback(obj.callback.add, obj.expression));
     if(obj.callback.change != undefined)


### PR DESCRIPTION
Great module! Thank you!

Small edit... Triggers were firing during the initialization process while directories were being scanned, and before any changes had occurred within the watched files/directories. I configured the `ignoreInitial` setting to `true` in your code's `chokidar.watch()` method to prevent that behavior.
